### PR TITLE
Switch from `/usr/bin` to `/usr/bin/env`

### DIFF
--- a/bin/gdaisy
+++ b/bin/gdaisy
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 if (php_sapi_name() !== 'cli') {


### PR DESCRIPTION
This PR switches `bin/gdaisy` to use `/usr/bin/env php` instead of `/usr/bin/php`, this lets the end-users environment pick which PHP version to use via its PATH, as oppose to `gdaisy` pointing to a specific version.

For me, this fixes the issue of `gdaisy` using the built-in PHP 7.1 instead of my homebrew versions, causing me to manually change the vendor file directly to get it to work instead of throwing parse errors.

![Screen Shot 2021-06-09 at 10 04 31 PM](https://user-images.githubusercontent.com/2221746/121422131-2f79db00-c96f-11eb-8672-df9fada050b4.png)

This is also an accepted practice, Laravel's [artisan] command uses this shebang, as well as Symfony in their [Creating a Console Application] example.

[artisan]: https://github.com/laravel/laravel/blob/0296bb63e1d465bcfff1f84f00313aeb26a2c84b/artisan#L1
[Creating a Console Application]: https://symfony.com/doc/current/components/console.html#creating-a-console-application
