### PR TITLE
Add support for PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     },
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "ext-gd": "*",
         "ext-json": "*",
         "minicli/minicli": "^2.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0809680f38e42d3a5aff24c7118cf12",
+    "content-hash": "c9dfae2dd8ae0f327fb0663faeb0aa3c",
     "packages": [
         {
             "name": "minicli/minicli",
@@ -3605,10 +3605,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "ext-gd": "*",
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
This PR adds support for PHP8, which `gdaisy` doesn't currently have. `minicli` supports PHP8 though, so `gdaisy` doesn't have any requirements that interfere with PHP8.

I did run the test suite on PHP 8.0.7 and got all greens, also symlinked this branch locally and went through requiring it and generating an image, and everything went smoothly there. 👍

![Screen Shot 2021-06-11 at 7 50 24 PM](https://user-images.githubusercontent.com/2221746/121729044-4eeb4200-caee-11eb-9d38-8579d003be42.png)